### PR TITLE
Corrects issue with links without actions on bbox-layout-links

### DIFF
--- a/utils/pdftotext.cc
+++ b/utils/pdftotext.cc
@@ -537,7 +537,7 @@ void printDocLinks(FILE *f, PDFDoc *doc, int page){
       link = linksList->getLink(i);
 
       // we only show the links that are actionURI type
-      if(link->getAction()->getKind() == actionURI){
+      if(link->getAction() && link->getAction()->getKind() == actionURI){
         LinkURI *ha=(LinkURI *) link->getAction();
         if (ha->isOk()) {
             link->getRect(&x1, &y1, &x2, &y2);


### PR DESCRIPTION
Source: https://tasks.hubstaff.com/app/projects/387/tasks/17762
QA: https://tasks.hubstaff.com/app/projects/372/tasks/17834

Description: There is an issue with pdf's that have links without actions. It ends up with a segmentation fault.

